### PR TITLE
log only to console by default

### DIFF
--- a/java/mtsj/server/src/main/resources/logback.xml
+++ b/java/mtsj/server/src/main/resources/logback.xml
@@ -4,7 +4,8 @@
   <property resource="io/oasp/logging/logback/application-logging.properties" />
   <property name="appname" value="mtsj"/>
   <property name="logPath" value="../logs"/>
-  <include resource="io/oasp/logging/logback/appenders-file-all.xml" />
+  <!-- uncomment appenders-file-all for writing logs to file-->
+  <!-- <include resource="io/oasp/logging/logback/appenders-file-all.xml" /> -->
   <include resource="io/oasp/logging/logback/appender-console.xml" />
 
   <root level="DEBUG">


### PR DESCRIPTION
Logging to file is not valid for cloud deployments, make "cloud native" by default