### PR TITLE
Insert angular 4 httpclient on rest services of my thai star

### DIFF
--- a/angular/src/app/app-routing.module.ts
+++ b/angular/src/app/app-routing.module.ts
@@ -17,7 +17,7 @@ const appRoutes: Routes = [
   { path: 'bookTable', component: BookTableComponent},
   { path: 'orders', component: OrderCockpitComponent, canActivate: [AuthGuardService]},
   { path: 'reservations', component: ReservationCockpitComponent, canActivate: [AuthGuardService]},
-  { path: '**', component: NotFoundComponent }];
+  /* { path: '**', component: NotFoundComponent }]; */
 
 @NgModule({
   imports: [

--- a/angular/src/app/app-routing.module.ts
+++ b/angular/src/app/app-routing.module.ts
@@ -17,7 +17,7 @@ const appRoutes: Routes = [
   { path: 'bookTable', component: BookTableComponent},
   { path: 'orders', component: OrderCockpitComponent, canActivate: [AuthGuardService]},
   { path: 'reservations', component: ReservationCockpitComponent, canActivate: [AuthGuardService]},
-  /* { path: '**', component: NotFoundComponent }]; */
+  /* { path: '**', component: NotFoundComponent }*/ ]; 
 
 @NgModule({
   imports: [

--- a/angular/src/app/app-routing.module.ts
+++ b/angular/src/app/app-routing.module.ts
@@ -17,8 +17,7 @@ const appRoutes: Routes = [
   { path: 'bookTable', component: BookTableComponent},
   { path: 'orders', component: OrderCockpitComponent, canActivate: [AuthGuardService]},
   { path: 'reservations', component: ReservationCockpitComponent, canActivate: [AuthGuardService]},
-  /* { path: '**', component: NotFoundComponent } */
-];
+  { path: '**', component: NotFoundComponent }];
 
 @NgModule({
   imports: [

--- a/angular/src/app/app-routing.module.ts
+++ b/angular/src/app/app-routing.module.ts
@@ -17,7 +17,8 @@ const appRoutes: Routes = [
   { path: 'bookTable', component: BookTableComponent},
   { path: 'orders', component: OrderCockpitComponent, canActivate: [AuthGuardService]},
   { path: 'reservations', component: ReservationCockpitComponent, canActivate: [AuthGuardService]},
-  { path: '**', component: NotFoundComponent }];
+  /* { path: '**', component: NotFoundComponent } */
+];
 
 @NgModule({
   imports: [

--- a/angular/src/app/app.component.spec.ts
+++ b/angular/src/app/app.component.spec.ts
@@ -14,6 +14,8 @@ import { AuthService } from './core/authentication/auth.service';
 import { AppComponent } from './app.component';
 import { HeaderComponent } from './header/header.component';
 
+import { HttpClientModule } from '@angular/common/http';
+
 describe('AppComponent', () => {
   let component: AppComponent;
   let fixture: ComponentFixture<AppComponent>;
@@ -28,6 +30,7 @@ describe('AppComponent', () => {
         BackendModule.forRoot({environmentType: 0, restServiceRoot: 'v1'}),
         CoreModule,
         SidenavModule,
+        HttpClientModule,
       ],
     });
     TestBed.compileComponents();

--- a/angular/src/app/app.module.ts
+++ b/angular/src/app/app.module.ts
@@ -5,6 +5,8 @@ import { NgModule, Type } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule }  from '@angular/platform-browser';
 import { HttpModule } from '@angular/http';
+import { HttpClientModule } from '@angular/common/http';
+import { InterceptorModule } from './core/httpClient/Interceptor.module';
 import { BackendModule } from './backend/backend.module';
 import { SidenavModule } from './sidenav/sidenav.module';
 import { BookTableModule } from './book-table/book-table.module';
@@ -34,6 +36,8 @@ import { AppRoutingModule } from './app-routing.module';
     BackendModule.forRoot({restServiceRoot: config.restServiceRoot, environmentType: environment.backendType}),
     EmailConfirmationModule,
     AppRoutingModule,
+    InterceptorModule,
+    HttpClientModule,
   ],
   providers: [],
   bootstrap: [ AppComponent ],

--- a/angular/src/app/backend/booking/booking-data-service-interface.ts
+++ b/angular/src/app/backend/booking/booking-data-service-interface.ts
@@ -1,12 +1,17 @@
 import { Observable } from 'rxjs/Observable';
-import { ReservationView } from '../../shared/viewModels/interfaces';
+import {
+    BookingResponse,
+    BookingTableResponse,
+    InvitationResponse,
+    ReservationView,
+} from '../../shared/viewModels/interfaces';
 import { BookingInfo, FilterCockpit } from '../backendModels/interfaces';
 
 export interface IBookingDataService {
 
-    getReservations(filter: FilterCockpit): Observable<ReservationView[]>;
-    bookTable(booking: BookingInfo): Observable<number>;
-    acceptInvite(token: string): Observable<number>;
-    cancelInvite(token: string): Observable<number>;
-    cancelReserve(token: string): Observable<number>;
+    getReservations(filter: FilterCockpit): Observable<BookingResponse[]>;
+    bookTable(booking: BookingInfo): Observable<BookingTableResponse>;
+    acceptInvite(token: string): Observable<InvitationResponse>;
+    cancelInvite(token: string): Observable<InvitationResponse>;
+    cancelReserve(token: string): Observable<InvitationResponse>;
 }

--- a/angular/src/app/backend/booking/booking-data-service.ts
+++ b/angular/src/app/backend/booking/booking-data-service.ts
@@ -5,40 +5,46 @@ import { BackendConfig } from '../backend.module';
 import { BookingInMemoryService } from './booking-in-memory.service';
 import { BookingRestService } from './booking-rest.service';
 import { IBookingDataService } from './booking-data-service-interface';
-import { ReservationView } from '../../shared/viewModels/interfaces';
+import {
+    BookingResponse,
+    BookingTableResponse,
+    InvitationResponse,
+    ReservationView,
+} from '../../shared/viewModels/interfaces';
 import { BookingInfo, FilterCockpit } from '../backendModels/interfaces';
+import { HttpClient } from '@angular/common/http';
 
 @Injectable()
 export class BookingDataService implements IBookingDataService {
 
     private usedImplementation: IBookingDataService;
 
-    constructor(private injector: Injector) {
+    constructor(private injector: Injector, private http: HttpClient) {
         const backendConfig: BackendConfig = this.injector.get(BackendConfig);
         if (backendConfig.environmentType === BackendType.IN_MEMORY) {
             this.usedImplementation = new BookingInMemoryService();
         } else { // default
-            this.usedImplementation = new BookingRestService(this.injector);
+            this.usedImplementation = new BookingRestService(http);
         }
     }
 
-    bookTable(booking: BookingInfo): Observable<number> {
+    bookTable(booking: BookingInfo): Observable<BookingTableResponse> {
         return this.usedImplementation.bookTable(booking);
     }
 
-    getReservations(filter: FilterCockpit): Observable<ReservationView[]> {
+    getReservations(filter: FilterCockpit): Observable<BookingResponse[]> {
         return this.usedImplementation.getReservations(filter);
     }
 
-    acceptInvite(token: string): Observable<number> {
-         return this.usedImplementation.acceptInvite(token);
-     }
+    acceptInvite(token: string): Observable<InvitationResponse> {
+        return this.usedImplementation.acceptInvite(token);
+    }
 
-    cancelInvite(token: string): Observable<number> {
-         return this.usedImplementation.cancelInvite(token);
-     }
+    cancelInvite(token: string): Observable<InvitationResponse> {
+        return this.usedImplementation.cancelInvite(token);
+    }
 
-    cancelReserve(token: string): Observable<number> {
-         return this.usedImplementation.cancelReserve(token);
-     }
+    cancelReserve(token: string): Observable<InvitationResponse> {
+        return this.usedImplementation.cancelReserve(token);
+    }
 }

--- a/angular/src/app/backend/booking/booking-data-service.ts
+++ b/angular/src/app/backend/booking/booking-data-service.ts
@@ -37,14 +37,14 @@ export class BookingDataService implements IBookingDataService {
     }
 
     acceptInvite(token: string): Observable<InvitationResponse> {
-         return this.usedImplementation.acceptInvite(token);
-     }
+        return this.usedImplementation.acceptInvite(token);
+    }
 
     cancelInvite(token: string): Observable<InvitationResponse> {
-         return this.usedImplementation.cancelInvite(token);
-     }
+        return this.usedImplementation.cancelInvite(token);
+    }
 
     cancelReserve(token: string): Observable<InvitationResponse> {
-         return this.usedImplementation.cancelReserve(token);
-     }
+        return this.usedImplementation.cancelReserve(token);
+    }
 }

--- a/angular/src/app/backend/booking/booking-data-service.ts
+++ b/angular/src/app/backend/booking/booking-data-service.ts
@@ -37,14 +37,14 @@ export class BookingDataService implements IBookingDataService {
     }
 
     acceptInvite(token: string): Observable<InvitationResponse> {
-        return this.usedImplementation.acceptInvite(token);
-    }
+         return this.usedImplementation.acceptInvite(token);
+     }
 
     cancelInvite(token: string): Observable<InvitationResponse> {
-        return this.usedImplementation.cancelInvite(token);
-    }
+         return this.usedImplementation.cancelInvite(token);
+     }
 
     cancelReserve(token: string): Observable<InvitationResponse> {
-        return this.usedImplementation.cancelReserve(token);
-    }
+         return this.usedImplementation.cancelReserve(token);
+     }
 }

--- a/angular/src/app/backend/booking/booking-in-memory.service.ts
+++ b/angular/src/app/backend/booking/booking-in-memory.service.ts
@@ -10,7 +10,7 @@ import { assign, maxBy, filter, toString, orderBy } from 'lodash';
 @Injectable()
 export class BookingInMemoryService implements IBookingDataService {
 
-    bookTable(booking: BookingInfo): Observable<number> {
+    bookTable(booking: BookingInfo): Observable<any> {
         let bookTable: ReservationView;
         bookTable = assign(bookTable, booking);
         bookTable.booking.creationDate = moment().format('LLL');
@@ -35,38 +35,38 @@ export class BookingInMemoryService implements IBookingDataService {
                 total: bookedTables.length,
             },
             result: orderBy(bookedTables, [filters.sort[0].name], [filters.sort[0].direction])
-                    .filter((booking: ReservationView) => {
-                        if (filters.bookingDate) {
-                            return booking.booking.bookingDate.toLowerCase().includes(filters.bookingDate.toLowerCase());
-                        } else {
-                            return true;
-                        }
-                    }).filter((booking: ReservationView) => {
-                        if (filters.email) {
-                            return booking.booking.email.toLowerCase().includes(filters.email.toLowerCase());
-                        } else {
-                            return true;
-                        }
-                    }).filter((booking: ReservationView) => {
-                        if (filters.bookingToken) {
-                            return toString(booking.booking.bookingToken).includes(toString(filters.bookingToken));
-                        } else {
-                            return true;
-                        }
-                    }),
+                .filter((booking: ReservationView) => {
+                    if (filters.bookingDate) {
+                        return booking.booking.bookingDate.toLowerCase().includes(filters.bookingDate.toLowerCase());
+                    } else {
+                        return true;
+                    }
+                }).filter((booking: ReservationView) => {
+                    if (filters.email) {
+                        return booking.booking.email.toLowerCase().includes(filters.email.toLowerCase());
+                    } else {
+                        return true;
+                    }
+                }).filter((booking: ReservationView) => {
+                    if (filters.bookingToken) {
+                        return toString(booking.booking.bookingToken).includes(toString(filters.bookingToken));
+                    } else {
+                        return true;
+                    }
+                }),
         });
     }
 
-    acceptInvite(token: string): Observable<number> {
+    acceptInvite(token: string): Observable<any> {
         return Observable.of(1);
-     }
+    }
 
-    cancelInvite(token: string): Observable<number> {
+    cancelInvite(token: string): Observable<any> {
         return Observable.of(1);
-     }
+    }
 
-    cancelReserve(token: string): Observable<number> {
+    cancelReserve(token: string): Observable<any> {
         return Observable.of(1);
-     }
+    }
 
 }

--- a/angular/src/app/backend/booking/booking-rest.service.spec.ts
+++ b/angular/src/app/backend/booking/booking-rest.service.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { TestBed, inject } from '@angular/core/testing';
 import {
   BaseRequestOptions,
@@ -9,7 +10,6 @@ import {
 import { MockBackend } from '@angular/http/testing';
 import { BookingRestService } from './booking-rest.service';
 import { CoreModule } from '../../core/core.module';
-import { HttpClientService } from '../../core/httpClient/httpClient.service';
 import { AuthService } from '../../core/authentication/auth.service';
 import { SnackBarService } from '../../core/snackService/snackService.service';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -20,15 +20,15 @@ import { WindowService } from '../../core/windowService/windowService.service';
 describe('BookingRestService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpModule, CoreModule, RouterTestingModule],
+      imports: [HttpModule, CoreModule, RouterTestingModule, HttpClientModule],
       providers: [
         BookingRestService,
-        HttpClientService,
         AuthService,
         SnackBarService,
         MockBackend,
         BaseRequestOptions,
         WindowService,
+        HttpClient,
         {provide: LoginDataService, useClass: LoginInMemoryService},
       ],
     });

--- a/angular/src/app/backend/booking/booking-rest.service.ts
+++ b/angular/src/app/backend/booking/booking-rest.service.ts
@@ -4,9 +4,14 @@ import { Response, Http } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { IBookingDataService } from './booking-data-service-interface';
 import { BookingInfo, FilterCockpit } from '../backendModels/interfaces';
-import { ReservationView } from '../../shared/viewModels/interfaces';
+import {
+    BookingResponse,
+    BookingTableResponse,
+    InvitationResponse,
+    ReservationView,
+} from '../../shared/viewModels/interfaces';
 import { config } from '../../config';
-import { HttpClientService } from '../../core/httpClient/httpClient.service';
+import { HttpClient } from '@angular/common/http';
 
 @Injectable()
 export class BookingRestService implements IBookingDataService {
@@ -17,38 +22,37 @@ export class BookingRestService implements IBookingDataService {
   private readonly cancelReserveRestPath: string = 'bookingmanagement/v1/booking/cancel/';
   private readonly getReservationsRestPath: string = 'bookingmanagement/v1/booking/search';
 
-  private http: HttpClientService;
+  // private http: HttpClientService;
+  // private http: HttpClient;
 
-  constructor(private injector: Injector) {
-    this.http = this.injector.get(HttpClientService);
-  }
+  constructor(private http: HttpClient) {}
 
-  bookTable(booking: BookingInfo): Observable < number > {
+  bookTable(booking: BookingInfo): Observable < BookingTableResponse > {
     return this.http.post(`${environment.restServiceRoot}${this.booktableRestPath}`, booking)
-      .map((res: Response) => res.json());
+      .map((res: BookingTableResponse) => res);
 
   }
 
-  getReservations(filter: FilterCockpit): Observable < ReservationView[] > {
+  getReservations(filter: FilterCockpit): Observable < BookingResponse[] > {
     return this.http.post(`${environment.restServiceRoot}${this.getReservationsRestPath}`, filter)
-      .map((res: Response) => res.json());
+      .map((res: BookingResponse[]) => res);
   }
 
-  acceptInvite(token: string): Observable < number > {
+  acceptInvite(token: string): Observable < InvitationResponse > {
     return this.http.get(`${environment.restServiceRoot}${this.acceptReserveRestPath}` + token)
-      .map((res: Response) => res.json());
+      .map((res: InvitationResponse) => res);
 
   }
 
-  cancelInvite(token: string): Observable < number > {
+  cancelInvite(token: string): Observable < InvitationResponse > {
     return this.http.get(`${environment.restServiceRoot}${this.rejectReserveRestPath}` + token)
-      .map((res: Response) => res.json());
+      .map((res: InvitationResponse) => res);
 
   }
 
-  cancelReserve(token: string): Observable < number > {
+  cancelReserve(token: string): Observable < InvitationResponse > {
     return this.http.get(`${environment.restServiceRoot}${this.cancelReserveRestPath}` + token)
-      .map((res: Response) => res.json());
+      .map((res: InvitationResponse) => res);
 
   }
 

--- a/angular/src/app/backend/booking/booking-rest.service.ts
+++ b/angular/src/app/backend/booking/booking-rest.service.ts
@@ -11,7 +11,6 @@ import {
     ReservationView,
 } from '../../shared/viewModels/interfaces';
 import { config } from '../../config';
-/* import { HttpClientService } from '../../core/httpClient/httpClient.service'; */
 import { HttpClient } from '@angular/common/http';
 
 @Injectable()

--- a/angular/src/app/backend/booking/booking-rest.service.ts
+++ b/angular/src/app/backend/booking/booking-rest.service.ts
@@ -11,6 +11,7 @@ import {
     ReservationView,
 } from '../../shared/viewModels/interfaces';
 import { config } from '../../config';
+/* import { HttpClientService } from '../../core/httpClient/httpClient.service'; */
 import { HttpClient } from '@angular/common/http';
 
 @Injectable()

--- a/angular/src/app/backend/dishes/dishes-data-service.ts
+++ b/angular/src/app/backend/dishes/dishes-data-service.ts
@@ -16,10 +16,10 @@ export class DishesDataService implements IDishesDataService {
     private usedImplementation: IDishesDataService;
 
     constructor(private injector: Injector, private http: HttpClient) {
-        const backendConfig: BackendConfig = this.injector.get(BackendConfig);
+        const backendConfig: BackendConfig =   this.injector.get(BackendConfig);
         if (backendConfig.environmentType === BackendType.IN_MEMORY) {
             this.usedImplementation = new DishesInMemoryService();
-        } else if (backendConfig.environmentType === BackendType.GRAPHQL) {
+        } else if (backendConfig.environmentType === BackendType.GRAPHQL)  {
             this.usedImplementation = new DishesGraphQlService(this.injector);
         } else { // default
             this.usedImplementation = new DishesRestService(http);

--- a/angular/src/app/backend/dishes/dishes-data-service.ts
+++ b/angular/src/app/backend/dishes/dishes-data-service.ts
@@ -16,10 +16,10 @@ export class DishesDataService implements IDishesDataService {
     private usedImplementation: IDishesDataService;
 
     constructor(private injector: Injector, private http: HttpClient) {
-        const backendConfig: BackendConfig =   this.injector.get(BackendConfig);
+        const backendConfig: BackendConfig = this.injector.get(BackendConfig);
         if (backendConfig.environmentType === BackendType.IN_MEMORY) {
             this.usedImplementation = new DishesInMemoryService();
-        } else if (backendConfig.environmentType === BackendType.GRAPHQL)  {
+        } else if (backendConfig.environmentType === BackendType.GRAPHQL) {
             this.usedImplementation = new DishesGraphQlService(this.injector);
         } else { // default
             this.usedImplementation = new DishesRestService(http);

--- a/angular/src/app/backend/dishes/dishes-data-service.ts
+++ b/angular/src/app/backend/dishes/dishes-data-service.ts
@@ -8,20 +8,21 @@ import { DishesRestService } from './dishes-rest.service';
 import { Filter } from '../backendModels/interfaces';
 import { IDishesDataService } from './dishes-data-service-interface';
 import { DishView } from '../../shared/viewModels/interfaces';
+import { HttpClient } from '@angular/common/http';
 
 @Injectable()
 export class DishesDataService implements IDishesDataService {
 
     private usedImplementation: IDishesDataService;
 
-    constructor(private injector: Injector) {
-        const backendConfig: BackendConfig =   this.injector.get(BackendConfig);
+    constructor(private injector: Injector, private http: HttpClient) {
+        const backendConfig: BackendConfig = this.injector.get(BackendConfig);
         if (backendConfig.environmentType === BackendType.IN_MEMORY) {
             this.usedImplementation = new DishesInMemoryService();
-        } else if (backendConfig.environmentType === BackendType.GRAPHQL)  {
+        } else if (backendConfig.environmentType === BackendType.GRAPHQL) {
             this.usedImplementation = new DishesGraphQlService(this.injector);
         } else { // default
-            this.usedImplementation = new DishesRestService(this.injector);
+            this.usedImplementation = new DishesRestService(http);
         }
     }
 

--- a/angular/src/app/backend/dishes/dishes-graph-ql.service.ts
+++ b/angular/src/app/backend/dishes/dishes-graph-ql.service.ts
@@ -31,15 +31,15 @@ const getDishesQuery: any = gql`
 // and java server implementation, model was not yet established so for now conversion
 // will be implemented as a part of this service to expose consistient service API
 class GqlDish {
-  id: number; // added by Roberto, please revise
-  image: string;
-  likes: number;
-  ingredients: { id: number, name: string, price: number }[];
-  description: string;
-  name: string;
-  price: number;
-  categories: [ // added by Roberto, please revise
-    { id: string }];
+    id: number; // added by Roberto, please revise
+    image: string;
+    likes: number;
+    ingredients: {id: number, name: string, price: number}[];
+    description: string;
+    name: string;
+    price: number;
+    categories: [ // added by Roberto, please revise
+      {id: string}];
 }
 
 class DishesQueryRepsonse {
@@ -56,7 +56,7 @@ export class DishesGraphQlService implements IDishesDataService {
   }
 
   // added by Roberto, please, revise
-  filter(filters: Filter): Observable<DishView[]> {
+  filter(filters: Filter): Observable <DishView[]> {
     return this.apollo.watchQuery<DishesQueryRepsonse>({ query: getDishesQuery })
       .map((result: ApolloQueryResult<DishesQueryRepsonse>) => result.data.dishes)
       .map((dishes: GqlDish[]) => dishes.map(this.convertToBackendDish));
@@ -64,18 +64,18 @@ export class DishesGraphQlService implements IDishesDataService {
 
   // TODO: see the comment above
   private convertToBackendDish(dish: GqlDish): DishView {
-    return {
-      dish: {
-        id: dish.id, // added by Roberto, please revise
-        description: dish.description,
-        name: dish.name,
-        price: dish.price,
-      },
-      isfav: false,
-      image: { content: dish.image },
-      likes: dish.likes,
-      extras: dish.ingredients.map((extra: any) => ({ id: extra.id, name: extra.name, price: extra.price, selected: false })),
-      categories: dish.categories, // added by Roberto, please revise
-    };
+   return {
+        dish: {
+          id: dish.id, // added by Roberto, please revise
+          description: dish.description,
+          name: dish.name,
+          price: dish.price,
+        },
+        isfav: false,
+        image: {content: dish.image},
+        likes: dish.likes,
+        extras: dish.ingredients.map((extra: any) => ({id: extra.id, name: extra.name, price: extra.price, selected: false})),
+        categories: dish.categories, // added by Roberto, please revise
+      };
   }
 }

--- a/angular/src/app/backend/dishes/dishes-graph-ql.service.ts
+++ b/angular/src/app/backend/dishes/dishes-graph-ql.service.ts
@@ -31,15 +31,15 @@ const getDishesQuery: any = gql`
 // and java server implementation, model was not yet established so for now conversion
 // will be implemented as a part of this service to expose consistient service API
 class GqlDish {
-    id: number; // added by Roberto, please revise
-    image: string;
-    likes: number;
-    ingredients: {id: number, name: string, price: number}[];
-    description: string;
-    name: string;
-    price: number;
-    categories: [ // added by Roberto, please revise
-      {id: string}];
+  id: number; // added by Roberto, please revise
+  image: string;
+  likes: number;
+  ingredients: { id: number, name: string, price: number }[];
+  description: string;
+  name: string;
+  price: number;
+  categories: [ // added by Roberto, please revise
+    { id: string }];
 }
 
 class DishesQueryRepsonse {
@@ -56,7 +56,7 @@ export class DishesGraphQlService implements IDishesDataService {
   }
 
   // added by Roberto, please, revise
-  filter(filters: Filter): Observable <DishView[]> {
+  filter(filters: Filter): Observable<DishView[]> {
     return this.apollo.watchQuery<DishesQueryRepsonse>({ query: getDishesQuery })
       .map((result: ApolloQueryResult<DishesQueryRepsonse>) => result.data.dishes)
       .map((dishes: GqlDish[]) => dishes.map(this.convertToBackendDish));
@@ -64,18 +64,18 @@ export class DishesGraphQlService implements IDishesDataService {
 
   // TODO: see the comment above
   private convertToBackendDish(dish: GqlDish): DishView {
-   return {
-        dish: {
-          id: dish.id, // added by Roberto, please revise
-          description: dish.description,
-          name: dish.name,
-          price: dish.price,
-        },
-        isfav: false,
-        image: {content: dish.image},
-        likes: dish.likes,
-        extras: dish.ingredients.map((extra: any) => ({id: extra.id, name: extra.name, price: extra.price, selected: false})),
-        categories: dish.categories, // added by Roberto, please revise
-      };
+    return {
+      dish: {
+        id: dish.id, // added by Roberto, please revise
+        description: dish.description,
+        name: dish.name,
+        price: dish.price,
+      },
+      isfav: false,
+      image: { content: dish.image },
+      likes: dish.likes,
+      extras: dish.ingredients.map((extra: any) => ({ id: extra.id, name: extra.name, price: extra.price, selected: false })),
+      categories: dish.categories, // added by Roberto, please revise
+    };
   }
 }

--- a/angular/src/app/backend/dishes/dishes-rest.service.spec.ts
+++ b/angular/src/app/backend/dishes/dishes-rest.service.spec.ts
@@ -20,7 +20,7 @@ import { HttpClient, HttpClientModule } from '@angular/common/http';
 describe('DishesRestService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpModule, CoreModule, RouterTestingModule],
+      imports: [HttpModule, CoreModule, RouterTestingModule, HttpClientModule],
       providers: [
         DishesRestService,
         AuthService,

--- a/angular/src/app/backend/dishes/dishes-rest.service.spec.ts
+++ b/angular/src/app/backend/dishes/dishes-rest.service.spec.ts
@@ -20,7 +20,7 @@ import { HttpClient, HttpClientModule } from '@angular/common/http';
 describe('DishesRestService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpModule, CoreModule, RouterTestingModule, HttpClientModule],
+      imports: [HttpModule, CoreModule, RouterTestingModule],
       providers: [
         DishesRestService,
         AuthService,

--- a/angular/src/app/backend/dishes/dishes-rest.service.spec.ts
+++ b/angular/src/app/backend/dishes/dishes-rest.service.spec.ts
@@ -9,13 +9,13 @@ import {
 import { CoreModule } from '../../core/core.module';
 import { MockBackend } from '@angular/http/testing';
 import { DishesRestService } from './dishes-rest.service';
-import { HttpClientService } from '../../core/httpClient/httpClient.service';
 import { AuthService } from '../../core/authentication/auth.service';
 import { SnackBarService } from '../../core/snackService/snackService.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { LoginDataService } from '../login/login-data-service';
 import { WindowService } from '../../core/windowService/windowService.service';
 import { LoginInMemoryService } from '../login/login-in-memory.service';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 
 describe('DishesRestService', () => {
   beforeEach(() => {
@@ -23,12 +23,12 @@ describe('DishesRestService', () => {
       imports: [HttpModule, CoreModule, RouterTestingModule],
       providers: [
         DishesRestService,
-        HttpClientService,
         AuthService,
         SnackBarService,
         MockBackend,
         BaseRequestOptions,
         WindowService,
+        HttpClient,
         {provide: LoginDataService, useClass: LoginInMemoryService},
       ],
     });

--- a/angular/src/app/backend/dishes/dishes-rest.service.ts
+++ b/angular/src/app/backend/dishes/dishes-rest.service.ts
@@ -5,23 +5,23 @@ import { Response, Http, Headers } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { IDishesDataService } from './dishes-data-service-interface';
 import { config } from '../../config';
-import { DishView } from '../../shared/viewModels/interfaces';
-import { HttpClientService } from '../../core/httpClient/httpClient.service';
+import { DishResponse, DishView } from '../../shared/viewModels/interfaces';
+import { HttpClient } from '@angular/common/http';
 
 @Injectable()
 export class DishesRestService implements IDishesDataService {
 
- private readonly filtersRestPath: string = 'dishmanagement/v1/dish/search';
+  private readonly filtersRestPath: string = 'dishmanagement/v1/dish/search';
 
- private http: HttpClientService;
+  results: string[];
 
- constructor(private injector: Injector) {
-   this.http = this.injector.get(HttpClientService);
- }
+  constructor(private http: HttpClient) {
+  }
 
- filter(filters: Filter): Observable<DishView[]> {
-    return this.http.post(`${environment.restServiceRoot}${this.filtersRestPath}`, filters)
-                    .map((res: Response) => res.json().result);
- }
+  filter(filters: Filter): Observable<DishView[]> {
+    // Returns DishResponse
+    return this.http.post<DishResponse>(`${environment.restServiceRoot}${this.filtersRestPath}`, filters)
+      .map((res: any) => res.result);
+  }
 
 }

--- a/angular/src/app/backend/dishes/dishes-rest.service.ts
+++ b/angular/src/app/backend/dishes/dishes-rest.service.ts
@@ -11,17 +11,17 @@ import { HttpClient } from '@angular/common/http';
 @Injectable()
 export class DishesRestService implements IDishesDataService {
 
-    private readonly filtersRestPath: string = 'dishmanagement/v1/dish/search';
+  private readonly filtersRestPath: string = 'dishmanagement/v1/dish/search';
 
-    results: string[];
+  results: string[];
 
-    constructor(private http: HttpClient) {
-    }
+  constructor(private http: HttpClient) {
+  }
 
-    filter(filters: Filter): Observable<DishView[]> {
-        // Returns DishResponse
-        return this.http.post<DishResponse>(`${environment.restServiceRoot}${this.filtersRestPath}`, filters)
-            .map((res: any) => res.result);
-    }
+  filter(filters: Filter): Observable<DishView[]> {
+    // Returns DishResponse
+    return this.http.post<DishResponse>(`${environment.restServiceRoot}${this.filtersRestPath}`, filters)
+      .map((res: any) => res.result);
+  }
 
 }

--- a/angular/src/app/backend/dishes/dishes-rest.service.ts
+++ b/angular/src/app/backend/dishes/dishes-rest.service.ts
@@ -11,17 +11,17 @@ import { HttpClient } from '@angular/common/http';
 @Injectable()
 export class DishesRestService implements IDishesDataService {
 
-  private readonly filtersRestPath: string = 'dishmanagement/v1/dish/search';
+    private readonly filtersRestPath: string = 'dishmanagement/v1/dish/search';
 
-  results: string[];
+    results: string[];
 
-  constructor(private http: HttpClient) {
-  }
+    constructor(private http: HttpClient) {
+    }
 
-  filter(filters: Filter): Observable<DishView[]> {
-    // Returns DishResponse
-    return this.http.post<DishResponse>(`${environment.restServiceRoot}${this.filtersRestPath}`, filters)
-      .map((res: any) => res.result);
-  }
+    filter(filters: Filter): Observable<DishView[]> {
+        // Returns DishResponse
+        return this.http.post<DishResponse>(`${environment.restServiceRoot}${this.filtersRestPath}`, filters)
+            .map((res: any) => res.result);
+    }
 
 }

--- a/angular/src/app/backend/login/login-data-service.ts
+++ b/angular/src/app/backend/login/login-data-service.ts
@@ -1,3 +1,4 @@
+import { HttpClient } from '@angular/common/http';
 import { Injector, Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { BackendType } from './../../../app/config';
@@ -12,12 +13,12 @@ export class LoginDataService implements ILoginDataService {
 
     private usedImplementation: ILoginDataService;
 
-    constructor(public injector: Injector) {
-        const backendConfig: BackendConfig =   this.injector.get(BackendConfig);
+    constructor(public injector: Injector, private http: HttpClient) {
+        const backendConfig: BackendConfig = this.injector.get(BackendConfig);
         if (backendConfig.environmentType === BackendType.IN_MEMORY) {
             this.usedImplementation = new LoginInMemoryService();
         } else { // default
-            this.usedImplementation = new LoginRestService(this.injector);
+            this.usedImplementation = new LoginRestService(http);
         }
     }
 

--- a/angular/src/app/backend/login/login-data-service.ts
+++ b/angular/src/app/backend/login/login-data-service.ts
@@ -14,7 +14,7 @@ export class LoginDataService implements ILoginDataService {
     private usedImplementation: ILoginDataService;
 
     constructor(public injector: Injector, private http: HttpClient) {
-        const backendConfig: BackendConfig = this.injector.get(BackendConfig);
+        const backendConfig: BackendConfig =   this.injector.get(BackendConfig);
         if (backendConfig.environmentType === BackendType.IN_MEMORY) {
             this.usedImplementation = new LoginInMemoryService();
         } else { // default

--- a/angular/src/app/backend/login/login-data-service.ts
+++ b/angular/src/app/backend/login/login-data-service.ts
@@ -14,7 +14,7 @@ export class LoginDataService implements ILoginDataService {
     private usedImplementation: ILoginDataService;
 
     constructor(public injector: Injector, private http: HttpClient) {
-        const backendConfig: BackendConfig =   this.injector.get(BackendConfig);
+        const backendConfig: BackendConfig = this.injector.get(BackendConfig);
         if (backendConfig.environmentType === BackendType.IN_MEMORY) {
             this.usedImplementation = new LoginInMemoryService();
         } else { // default

--- a/angular/src/app/backend/login/login-rest.service.spec.ts
+++ b/angular/src/app/backend/login/login-rest.service.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { TestBed, inject } from '@angular/core/testing';
 import {
     BaseRequestOptions,
@@ -9,7 +10,6 @@ import {
 import { CoreModule } from '../../core/core.module';
 import { MockBackend } from '@angular/http/testing';
 import { LoginRestService } from './login-rest.service';
-import { HttpClientService } from '../../core/httpClient/httpClient.service';
 import { AuthService } from '../../core/authentication/auth.service';
 import { SnackBarService } from '../../core/snackService/snackService.service';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -20,15 +20,15 @@ import { LoginInMemoryService } from '../login/login-in-memory.service';
 describe('LoginRestService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpModule, CoreModule, RouterTestingModule],
+      imports: [HttpModule, CoreModule, RouterTestingModule, HttpClientModule],
       providers: [
         LoginRestService,
-        HttpClientService,
         AuthService,
         SnackBarService,
         MockBackend,
         BaseRequestOptions,
         WindowService,
+        HttpClient,
         {provide: LoginDataService, useClass: LoginInMemoryService},
       ],
     });

--- a/angular/src/app/backend/login/login-rest.service.ts
+++ b/angular/src/app/backend/login/login-rest.service.ts
@@ -1,3 +1,4 @@
+import { HttpClient } from '@angular/common/http';
 import { environment } from './../../../environments/environment';
 import { Injectable, Injector } from '@angular/core';
 import { Response, Http } from '@angular/http';
@@ -5,7 +6,6 @@ import { Observable } from 'rxjs/Observable';
 import { LoginInfo } from '../backendModels/interfaces';
 import { ILoginDataService } from './login-data-service-interface';
 import { config } from '../../config';
-import { HttpClientService } from '../../core/httpClient/httpClient.service';
 
 @Injectable()
 export class LoginRestService implements ILoginDataService {
@@ -16,31 +16,29 @@ export class LoginRestService implements ILoginDataService {
   private readonly registerRestPath: string = 'register';
   private readonly changePasswordRestPath: string = 'changepassword';
 
-  private http: HttpClientService;
+  constructor(private http: HttpClient) {}
 
-  constructor(private injector: Injector) {
-    this.http = this.injector.get(HttpClientService);
-  }
-
-  login(username: string, password: string): Observable<string> {
-    return this.http.post(`${environment.restPathRoot}${this.loginRestPath}`, {username: username, password: password});
+  login(username: string, password: string): Observable<any> {
+    return this.http.post(`${environment.restPathRoot}${this.loginRestPath}`,
+    {username: username, password: password}, {responseType: 'text', observe: 'response'})
+      /* .map((res) => {debugger; res}) */;
   }
 
   getCurrentUser(): Observable<LoginInfo> {
     return this.http.get(`${environment.restServiceRoot}${this.currentUserRestPath}`)
-      .map((res: Response) => res.json());
+      .map((res: LoginInfo) => res);
   }
 
   register(email: string, password: string): Observable<LoginInfo> {
     return this.http.post(`${environment.restServiceRoot}${this.registerRestPath}`, {email: email, password: password})
-      .map((res: Response) => res.json());
+      .map((res: LoginInfo) => res);
   }
 
   changePassword(username: string, oldPassword: string, newPassword: string): Observable<any> {
     return this.http.post(`${environment.restServiceRoot}${this.changePasswordRestPath}`,
         {username: username, oldPassword: oldPassword, newPassword: newPassword},
       )
-      .map((res: Response) => res.json());
+      .map((res: Response) => res);
   }
 
 }

--- a/angular/src/app/backend/order/order-data-service-interface.ts
+++ b/angular/src/app/backend/order/order-data-service-interface.ts
@@ -1,10 +1,10 @@
 import { Observable } from 'rxjs/Observable';
-import { OrderListView } from '../../shared/viewModels/interfaces';
+import { OrderListView, OrderResponse, SaveOrderResponse } from '../../shared/viewModels/interfaces';
 import { FilterCockpit, OrderListInfo } from '../backendModels/interfaces';
 
 export interface IOrderDataService {
 
-    getBookingOrders(filter: FilterCockpit): Observable<OrderListView[]>;
-    saveOrders(orders: OrderListInfo): Observable<number>;
-    cancelOrder(token: string): Observable<number>;
+    getBookingOrders(filter: FilterCockpit): Observable<OrderResponse[]>;
+    saveOrders(orders: OrderListInfo): Observable<SaveOrderResponse>;
+    cancelOrder(token: string): Observable<boolean>;
 }

--- a/angular/src/app/backend/order/order-data-service.ts
+++ b/angular/src/app/backend/order/order-data-service.ts
@@ -1,3 +1,4 @@
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 import { Injector, Injectable } from '@angular/core';
 import { BackendType } from './../../../app/config';
@@ -5,7 +6,7 @@ import { BackendConfig } from '../backend.module';
 import { OrderInMemoryService } from './order-in-memory.service';
 import { OrderRestService } from './order-rest.service';
 import { IOrderDataService } from './order-data-service-interface';
-import { OrderListView } from '../../shared/viewModels/interfaces';
+import { OrderListView, OrderResponse, SaveOrderResponse } from '../../shared/viewModels/interfaces';
 import { FilterCockpit, OrderListInfo } from '../backendModels/interfaces';
 
 @Injectable()
@@ -13,24 +14,24 @@ export class OrderDataService implements IOrderDataService {
 
     private usedImplementation: IOrderDataService;
 
-    constructor(private injector: Injector) {
+    constructor(private injector: Injector, private http: HttpClient) {
         const backendConfig: BackendConfig = this.injector.get(BackendConfig);
         if (backendConfig.environmentType === BackendType.IN_MEMORY) {
             this.usedImplementation = new OrderInMemoryService();
         } else { // default
-            this.usedImplementation = new OrderRestService(this.injector);
+            this.usedImplementation = new OrderRestService(http);
         }
     }
 
-    getBookingOrders(filter: FilterCockpit): Observable<OrderListView[]> {
+    getBookingOrders(filter: FilterCockpit): Observable<OrderResponse[]> {
         return this.usedImplementation.getBookingOrders(filter);
     }
 
-    saveOrders(orders: OrderListInfo): Observable<number> {
+    saveOrders(orders: OrderListInfo): Observable<SaveOrderResponse> {
         return this.usedImplementation.saveOrders(orders);
     }
 
-    cancelOrder(token: string): Observable<number> {
+    cancelOrder(token: string): Observable<boolean> {
          return this.usedImplementation.cancelOrder(token);
      }
 }

--- a/angular/src/app/backend/order/order-in-memory.service.ts
+++ b/angular/src/app/backend/order/order-in-memory.service.ts
@@ -23,25 +23,25 @@ export class OrderInMemoryService implements IOrderDataService {
                 total: orderList.length,
             },
             result: orderBy(orderList, [filters.sort[0].name], [filters.sort[0].direction])
-                .filter((order: OrderListView) => {
-                    if (filters.bookingDate) {
-                        return order.booking.bookingDate.toLowerCase().includes(filters.bookingDate.toLowerCase());
-                    } else {
-                        return true;
-                    }
-                }).filter((order: OrderListView) => {
-                    if (filters.email) {
-                        return order.booking.email.toLowerCase().includes(filters.email.toLowerCase());
-                    } else {
-                        return true;
-                    }
-                }).filter((order: OrderListView) => {
-                    if (filters.bookingToken) {
-                        return toString(order.booking.bookingToken).includes(toString(filters.bookingToken));
-                    } else {
-                        return true;
-                    }
-                }),
+                    .filter((order: OrderListView) => {
+                        if (filters.bookingDate) {
+                            return order.booking.bookingDate.toLowerCase().includes(filters.bookingDate.toLowerCase());
+                        } else {
+                            return true;
+                        }
+                    }).filter((order: OrderListView) => {
+                        if (filters.email) {
+                            return order.booking.email.toLowerCase().includes(filters.email.toLowerCase());
+                        } else {
+                            return true;
+                        }
+                    }).filter((order: OrderListView) => {
+                        if (filters.bookingToken) {
+                            return toString(order.booking.bookingToken).includes(toString(filters.bookingToken));
+                        } else {
+                            return true;
+                        }
+                    }),
         });
     }
 
@@ -57,7 +57,7 @@ export class OrderInMemoryService implements IOrderDataService {
         return find(dishes, (plate: DishView) => plate.dish.id === id);
     }
 
-    findReservationById(id: { bookingToken: string }): ReservationView {
+    findReservationById(id: {bookingToken: string}): ReservationView {
         return find(bookedTables, (booking: ReservationView) => booking.booking.bookingToken === toNumber(id.bookingToken));
     }
 
@@ -67,20 +67,20 @@ export class OrderInMemoryService implements IOrderDataService {
         orders.orderLines.forEach((order: OrderInfo) => {
             let plate: DishView = this.findDishById(order.orderLine.dishId);
             let _extras: ExtraView[] = [];
-            order.extras.forEach((extraId: any) => {
+            order.extras.forEach( (extraId: any) => {
                 _extras.push(this.findExtraById(extraId.id));
             });
             orderLines.push({
-                dish: {
-                    dishId: order.orderLine.dishId,
-                    name: plate.dish.name,
-                    price: plate.dish.price,
-                },
-                orderLine: {
-                    comment: order.orderLine.comment,
-                    amount: order.orderLine.amount,
-                },
-                extras: _extras,
+                    dish: {
+                        dishId: order.orderLine.dishId,
+                        name: plate.dish.name,
+                        price: plate.dish.price,
+                    },
+                    orderLine: {
+                        comment: order.orderLine.comment,
+                        amount: order.orderLine.amount,
+                    },
+                    extras: _extras,
             });
         });
 
@@ -101,6 +101,6 @@ export class OrderInMemoryService implements IOrderDataService {
 
     cancelOrder(token: string): Observable<boolean> {
         return Observable.of(true);
-    }
+     }
 
 }

--- a/angular/src/app/backend/order/order-in-memory.service.ts
+++ b/angular/src/app/backend/order/order-in-memory.service.ts
@@ -23,25 +23,25 @@ export class OrderInMemoryService implements IOrderDataService {
                 total: orderList.length,
             },
             result: orderBy(orderList, [filters.sort[0].name], [filters.sort[0].direction])
-                    .filter((order: OrderListView) => {
-                        if (filters.bookingDate) {
-                            return order.booking.bookingDate.toLowerCase().includes(filters.bookingDate.toLowerCase());
-                        } else {
-                            return true;
-                        }
-                    }).filter((order: OrderListView) => {
-                        if (filters.email) {
-                            return order.booking.email.toLowerCase().includes(filters.email.toLowerCase());
-                        } else {
-                            return true;
-                        }
-                    }).filter((order: OrderListView) => {
-                        if (filters.bookingToken) {
-                            return toString(order.booking.bookingToken).includes(toString(filters.bookingToken));
-                        } else {
-                            return true;
-                        }
-                    }),
+                .filter((order: OrderListView) => {
+                    if (filters.bookingDate) {
+                        return order.booking.bookingDate.toLowerCase().includes(filters.bookingDate.toLowerCase());
+                    } else {
+                        return true;
+                    }
+                }).filter((order: OrderListView) => {
+                    if (filters.email) {
+                        return order.booking.email.toLowerCase().includes(filters.email.toLowerCase());
+                    } else {
+                        return true;
+                    }
+                }).filter((order: OrderListView) => {
+                    if (filters.bookingToken) {
+                        return toString(order.booking.bookingToken).includes(toString(filters.bookingToken));
+                    } else {
+                        return true;
+                    }
+                }),
         });
     }
 
@@ -57,7 +57,7 @@ export class OrderInMemoryService implements IOrderDataService {
         return find(dishes, (plate: DishView) => plate.dish.id === id);
     }
 
-    findReservationById(id: {bookingToken: string}): ReservationView {
+    findReservationById(id: { bookingToken: string }): ReservationView {
         return find(bookedTables, (booking: ReservationView) => booking.booking.bookingToken === toNumber(id.bookingToken));
     }
 
@@ -67,20 +67,20 @@ export class OrderInMemoryService implements IOrderDataService {
         orders.orderLines.forEach((order: OrderInfo) => {
             let plate: DishView = this.findDishById(order.orderLine.dishId);
             let _extras: ExtraView[] = [];
-            order.extras.forEach( (extraId: any) => {
+            order.extras.forEach((extraId: any) => {
                 _extras.push(this.findExtraById(extraId.id));
             });
             orderLines.push({
-                    dish: {
-                        dishId: order.orderLine.dishId,
-                        name: plate.dish.name,
-                        price: plate.dish.price,
-                    },
-                    orderLine: {
-                        comment: order.orderLine.comment,
-                        amount: order.orderLine.amount,
-                    },
-                    extras: _extras,
+                dish: {
+                    dishId: order.orderLine.dishId,
+                    name: plate.dish.name,
+                    price: plate.dish.price,
+                },
+                orderLine: {
+                    comment: order.orderLine.comment,
+                    amount: order.orderLine.amount,
+                },
+                extras: _extras,
             });
         });
 
@@ -101,6 +101,6 @@ export class OrderInMemoryService implements IOrderDataService {
 
     cancelOrder(token: string): Observable<boolean> {
         return Observable.of(true);
-     }
+    }
 
 }

--- a/angular/src/app/backend/order/order-in-memory.service.ts
+++ b/angular/src/app/backend/order/order-in-memory.service.ts
@@ -23,29 +23,29 @@ export class OrderInMemoryService implements IOrderDataService {
                 total: orderList.length,
             },
             result: orderBy(orderList, [filters.sort[0].name], [filters.sort[0].direction])
-                    .filter((order: OrderListView) => {
-                        if (filters.bookingDate) {
-                            return order.booking.bookingDate.toLowerCase().includes(filters.bookingDate.toLowerCase());
-                        } else {
-                            return true;
-                        }
-                    }).filter((order: OrderListView) => {
-                        if (filters.email) {
-                            return order.booking.email.toLowerCase().includes(filters.email.toLowerCase());
-                        } else {
-                            return true;
-                        }
-                    }).filter((order: OrderListView) => {
-                        if (filters.bookingToken) {
-                            return toString(order.booking.bookingToken).includes(toString(filters.bookingToken));
-                        } else {
-                            return true;
-                        }
-                    }),
+                .filter((order: OrderListView) => {
+                    if (filters.bookingDate) {
+                        return order.booking.bookingDate.toLowerCase().includes(filters.bookingDate.toLowerCase());
+                    } else {
+                        return true;
+                    }
+                }).filter((order: OrderListView) => {
+                    if (filters.email) {
+                        return order.booking.email.toLowerCase().includes(filters.email.toLowerCase());
+                    } else {
+                        return true;
+                    }
+                }).filter((order: OrderListView) => {
+                    if (filters.bookingToken) {
+                        return toString(order.booking.bookingToken).includes(toString(filters.bookingToken));
+                    } else {
+                        return true;
+                    }
+                }),
         });
     }
 
-    saveOrders(order: OrderListInfo): Observable<number> {
+    saveOrders(order: OrderListInfo): Observable<any> {
         return Observable.of(orderList.push(this.composeOrderList(order)));
     }
 
@@ -57,7 +57,7 @@ export class OrderInMemoryService implements IOrderDataService {
         return find(dishes, (plate: DishView) => plate.dish.id === id);
     }
 
-    findReservationById(id: {bookingToken: string}): ReservationView {
+    findReservationById(id: { bookingToken: string }): ReservationView {
         return find(bookedTables, (booking: ReservationView) => booking.booking.bookingToken === toNumber(id.bookingToken));
     }
 
@@ -67,20 +67,20 @@ export class OrderInMemoryService implements IOrderDataService {
         orders.orderLines.forEach((order: OrderInfo) => {
             let plate: DishView = this.findDishById(order.orderLine.dishId);
             let _extras: ExtraView[] = [];
-            order.extras.forEach( (extraId: any) => {
+            order.extras.forEach((extraId: any) => {
                 _extras.push(this.findExtraById(extraId.id));
             });
             orderLines.push({
-                    dish: {
-                        dishId: order.orderLine.dishId,
-                        name: plate.dish.name,
-                        price: plate.dish.price,
-                    },
-                    orderLine: {
-                        comment: order.orderLine.comment,
-                        amount: order.orderLine.amount,
-                    },
-                    extras: _extras,
+                dish: {
+                    dishId: order.orderLine.dishId,
+                    name: plate.dish.name,
+                    price: plate.dish.price,
+                },
+                orderLine: {
+                    comment: order.orderLine.comment,
+                    amount: order.orderLine.amount,
+                },
+                extras: _extras,
             });
         });
 
@@ -99,8 +99,8 @@ export class OrderInMemoryService implements IOrderDataService {
         };
     }
 
-    cancelOrder(token: string): Observable<number> {
-        return Observable.of(1);
-     }
+    cancelOrder(token: string): Observable<boolean> {
+        return Observable.of(true);
+    }
 
 }

--- a/angular/src/app/backend/order/order-rest.service.spec.ts
+++ b/angular/src/app/backend/order/order-rest.service.spec.ts
@@ -1,11 +1,11 @@
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { TestBed, inject } from '@angular/core/testing';
 import {
-  BaseRequestOptions,
-  HttpModule,
-  Http,
-  Response,
-  ResponseOptions,
+    BaseRequestOptions,
+    HttpModule,
+    Http,
+    Response,
+    ResponseOptions,
 } from '@angular/http';
 import { CoreModule } from '../../core/core.module';
 import { MockBackend } from '@angular/http/testing';
@@ -30,7 +30,7 @@ describe('OrderRestService', () => {
         BaseRequestOptions,
         WindowService,
         HttpClient,
-        { provide: LoginDataService, useClass: LoginInMemoryService },
+        {provide: LoginDataService, useClass: LoginInMemoryService},
       ],
     });
   });

--- a/angular/src/app/backend/order/order-rest.service.spec.ts
+++ b/angular/src/app/backend/order/order-rest.service.spec.ts
@@ -1,11 +1,11 @@
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { TestBed, inject } from '@angular/core/testing';
 import {
-    BaseRequestOptions,
-    HttpModule,
-    Http,
-    Response,
-    ResponseOptions,
+  BaseRequestOptions,
+  HttpModule,
+  Http,
+  Response,
+  ResponseOptions,
 } from '@angular/http';
 import { CoreModule } from '../../core/core.module';
 import { MockBackend } from '@angular/http/testing';
@@ -30,7 +30,7 @@ describe('OrderRestService', () => {
         BaseRequestOptions,
         WindowService,
         HttpClient,
-        {provide: LoginDataService, useClass: LoginInMemoryService},
+        { provide: LoginDataService, useClass: LoginInMemoryService },
       ],
     });
   });

--- a/angular/src/app/backend/order/order-rest.service.spec.ts
+++ b/angular/src/app/backend/order/order-rest.service.spec.ts
@@ -1,15 +1,15 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { TestBed, inject } from '@angular/core/testing';
 import {
-    BaseRequestOptions,
-    HttpModule,
-    Http,
-    Response,
-    ResponseOptions,
+  BaseRequestOptions,
+  HttpModule,
+  Http,
+  Response,
+  ResponseOptions,
 } from '@angular/http';
 import { CoreModule } from '../../core/core.module';
 import { MockBackend } from '@angular/http/testing';
 import { OrderRestService } from './order-rest.service';
-import { HttpClientService } from '../../core/httpClient/httpClient.service';
 import { AuthService } from '../../core/authentication/auth.service';
 import { SnackBarService } from '../../core/snackService/snackService.service';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -21,16 +21,16 @@ import { WindowService } from '../../core/windowService/windowService.service';
 describe('OrderRestService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpModule, CoreModule, RouterTestingModule],
+      imports: [HttpModule, CoreModule, RouterTestingModule, HttpClientModule],
       providers: [
         OrderRestService,
-        HttpClientService,
         AuthService,
         SnackBarService,
         MockBackend,
         BaseRequestOptions,
         WindowService,
-        {provide: LoginDataService, useClass: LoginInMemoryService},
+        HttpClient,
+        { provide: LoginDataService, useClass: LoginInMemoryService },
       ],
     });
   });

--- a/angular/src/app/backend/order/order-rest.service.ts
+++ b/angular/src/app/backend/order/order-rest.service.ts
@@ -11,34 +11,34 @@ import { config } from '../../config';
 @Injectable()
 export class OrderRestService implements IOrderDataService {
 
-  private readonly getOrdersRestPath: string = 'ordermanagement/v1/order/search';
-  private readonly filterOrdersRestPath: string = 'ordermanagement/v1/order/filter';
-  private readonly cancelOrderRestPath: string = 'ordermanagement/v1/order/cancelorder/';
-  private readonly saveOrdersPath: string = 'ordermanagement/v1/order';
+     private readonly getOrdersRestPath: string = 'ordermanagement/v1/order/search';
+     private readonly filterOrdersRestPath: string = 'ordermanagement/v1/order/filter';
+     private readonly cancelOrderRestPath: string = 'ordermanagement/v1/order/cancelorder/';
+     private readonly saveOrdersPath: string = 'ordermanagement/v1/order';
 
-  constructor(private http: HttpClient) { }
+     constructor(private http: HttpClient) {}
 
-  getBookingOrders(filter: FilterCockpit): Observable<OrderResponse[]> {
-    let path: string;
-    if (filter.email || filter.bookingToken) {
-      path = this.filterOrdersRestPath;
-    } else {
-      delete filter.email;
-      delete filter.bookingToken;
-      path = this.getOrdersRestPath;
-    }
-    return this.http.post(`${environment.restServiceRoot}${path}`, filter)
-      .map((res: OrderResponse[]) => res);
-  }
+     getBookingOrders(filter: FilterCockpit): Observable<OrderResponse[]> {
+        let path: string;
+        if (filter.email || filter.bookingToken) {
+          path = this.filterOrdersRestPath;
+        } else {
+          delete filter.email;
+          delete filter.bookingToken;
+          path = this.getOrdersRestPath;
+        }
+        return this.http.post(`${environment.restServiceRoot}${path}`, filter)
+                        .map((res: OrderResponse[]) => res);
+     }
 
-  saveOrders(orders: OrderListInfo): Observable<SaveOrderResponse> {
-    return this.http.post(`${environment.restServiceRoot}${this.saveOrdersPath}`, orders)
-      .map((res: SaveOrderResponse) => res);
-  }
+     saveOrders(orders: OrderListInfo): Observable<SaveOrderResponse> {
+        return this.http.post(`${environment.restServiceRoot}${this.saveOrdersPath}`, orders)
+                        .map((res: SaveOrderResponse) => res);
+     }
 
-  cancelOrder(token: string): Observable<boolean> {
-    return this.http.get(`${environment.restServiceRoot}${this.cancelOrderRestPath}` + token)
-      .map((res: Response) => true);
-  }
+      cancelOrder(token: string): Observable<boolean> {
+        return this.http.get(`${environment.restServiceRoot}${this.cancelOrderRestPath}` + token)
+                        .map((res: Response) => true);
+      }
 
 }

--- a/angular/src/app/backend/order/order-rest.service.ts
+++ b/angular/src/app/backend/order/order-rest.service.ts
@@ -11,34 +11,34 @@ import { config } from '../../config';
 @Injectable()
 export class OrderRestService implements IOrderDataService {
 
-     private readonly getOrdersRestPath: string = 'ordermanagement/v1/order/search';
-     private readonly filterOrdersRestPath: string = 'ordermanagement/v1/order/filter';
-     private readonly cancelOrderRestPath: string = 'ordermanagement/v1/order/cancelorder/';
-     private readonly saveOrdersPath: string = 'ordermanagement/v1/order';
+  private readonly getOrdersRestPath: string = 'ordermanagement/v1/order/search';
+  private readonly filterOrdersRestPath: string = 'ordermanagement/v1/order/filter';
+  private readonly cancelOrderRestPath: string = 'ordermanagement/v1/order/cancelorder/';
+  private readonly saveOrdersPath: string = 'ordermanagement/v1/order';
 
-     constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient) { }
 
-     getBookingOrders(filter: FilterCockpit): Observable<OrderResponse[]> {
-        let path: string;
-        if (filter.email || filter.bookingToken) {
-          path = this.filterOrdersRestPath;
-        } else {
-          delete filter.email;
-          delete filter.bookingToken;
-          path = this.getOrdersRestPath;
-        }
-        return this.http.post(`${environment.restServiceRoot}${path}`, filter)
-                        .map((res: OrderResponse[]) => res);
-     }
+  getBookingOrders(filter: FilterCockpit): Observable<OrderResponse[]> {
+    let path: string;
+    if (filter.email || filter.bookingToken) {
+      path = this.filterOrdersRestPath;
+    } else {
+      delete filter.email;
+      delete filter.bookingToken;
+      path = this.getOrdersRestPath;
+    }
+    return this.http.post(`${environment.restServiceRoot}${path}`, filter)
+      .map((res: OrderResponse[]) => res);
+  }
 
-     saveOrders(orders: OrderListInfo): Observable<SaveOrderResponse> {
-        return this.http.post(`${environment.restServiceRoot}${this.saveOrdersPath}`, orders)
-                        .map((res: SaveOrderResponse) => res);
-     }
+  saveOrders(orders: OrderListInfo): Observable<SaveOrderResponse> {
+    return this.http.post(`${environment.restServiceRoot}${this.saveOrdersPath}`, orders)
+      .map((res: SaveOrderResponse) => res);
+  }
 
-      cancelOrder(token: string): Observable<boolean> {
-        return this.http.get(`${environment.restServiceRoot}${this.cancelOrderRestPath}` + token)
-                        .map((res: Response) => true);
-      }
+  cancelOrder(token: string): Observable<boolean> {
+    return this.http.get(`${environment.restServiceRoot}${this.cancelOrderRestPath}` + token)
+      .map((res: Response) => true);
+  }
 
 }

--- a/angular/src/app/backend/order/order-rest.service.ts
+++ b/angular/src/app/backend/order/order-rest.service.ts
@@ -1,48 +1,44 @@
+import { HttpClient } from '@angular/common/http';
 import { environment } from './../../../environments/environment';
 import { Injectable, Injector } from '@angular/core';
 import { Response, Http } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { IOrderDataService } from './order-data-service-interface';
 import { FilterCockpit, OrderListInfo } from '../backendModels/interfaces';
-import { OrderListView } from '../../shared/viewModels/interfaces';
+import { OrderListView, OrderResponse, SaveOrderResponse } from '../../shared/viewModels/interfaces';
 import { config } from '../../config';
-import { HttpClientService } from '../../core/httpClient/httpClient.service';
 
 @Injectable()
 export class OrderRestService implements IOrderDataService {
 
-     private readonly getOrdersRestPath: string = 'ordermanagement/v1/order/search';
-     private readonly filterOrdersRestPath: string = 'ordermanagement/v1/order/filter';
-     private readonly cancelOrderRestPath: string = 'ordermanagement/v1/order/cancelorder/';
-     private readonly saveOrdersPath: string = 'ordermanagement/v1/order';
+  private readonly getOrdersRestPath: string = 'ordermanagement/v1/order/search';
+  private readonly filterOrdersRestPath: string = 'ordermanagement/v1/order/filter';
+  private readonly cancelOrderRestPath: string = 'ordermanagement/v1/order/cancelorder/';
+  private readonly saveOrdersPath: string = 'ordermanagement/v1/order';
 
-     private http: HttpClientService;
+  constructor(private http: HttpClient) { }
 
-     constructor(private injector: Injector) {
-       this.http = this.injector.get(HttpClientService);
-     }
+  getBookingOrders(filter: FilterCockpit): Observable<OrderResponse[]> {
+    let path: string;
+    if (filter.email || filter.bookingToken) {
+      path = this.filterOrdersRestPath;
+    } else {
+      delete filter.email;
+      delete filter.bookingToken;
+      path = this.getOrdersRestPath;
+    }
+    return this.http.post(`${environment.restServiceRoot}${path}`, filter)
+      .map((res: OrderResponse[]) => res);
+  }
 
-     getBookingOrders(filter: FilterCockpit): Observable<OrderListView[]> {
-        let path: string;
-        if (filter.email || filter.bookingToken) {
-          path = this.filterOrdersRestPath;
-        } else {
-          delete filter.email;
-          delete filter.bookingToken;
-          path = this.getOrdersRestPath;
-        }
-        return this.http.post(`${environment.restServiceRoot}${path}`, filter)
-                        .map((res: Response) => res.json());
-     }
+  saveOrders(orders: OrderListInfo): Observable<SaveOrderResponse> {
+    return this.http.post(`${environment.restServiceRoot}${this.saveOrdersPath}`, orders)
+      .map((res: SaveOrderResponse) => res);
+  }
 
-     saveOrders(orders: OrderListInfo): Observable<number> {
-        return this.http.post(`${environment.restServiceRoot}${this.saveOrdersPath}`, orders)
-                        .map((res: Response) => res.json());
-     }
-
-      cancelOrder(token: string): Observable<number> {
-        return this.http.get(`${environment.restServiceRoot}${this.cancelOrderRestPath}` + token)
-                        .map((res: Response) => res.json());
-      }
+  cancelOrder(token: string): Observable<boolean> {
+    return this.http.get(`${environment.restServiceRoot}${this.cancelOrderRestPath}` + token)
+      .map((res: Response) => true);
+  }
 
 }

--- a/angular/src/app/book-table/book-table-dialog/book-table-dialog.component.spec.ts
+++ b/angular/src/app/book-table/book-table-dialog/book-table-dialog.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
@@ -16,14 +17,15 @@ describe('BookTableDialogComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      providers: [SnackBarService, BookTableService],
+      providers: [SnackBarService, BookTableService, HttpClient],
       imports: [
         BrowserAnimationsModule,
         BookTableModule,
-        BackendModule.forRoot({environmentType: 0, restServiceRoot: 'v1'}),
+        HttpClientModule,
+        BackendModule.forRoot({ environmentType: 0, restServiceRoot: 'v1' }),
       ],
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/angular/src/app/book-table/invitation-dialog/invitation-dialog.component.spec.ts
+++ b/angular/src/app/book-table/invitation-dialog/invitation-dialog.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDialog } from '@angular/material';
@@ -16,10 +17,11 @@ describe('InvitationDialogComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      providers: [SnackBarService, BookTableService],
+      providers: [SnackBarService, BookTableService, HttpClient],
       imports: [
         BrowserAnimationsModule,
         BookTableModule,
+        HttpClientModule,
         BackendModule.forRoot({environmentType: 0, restServiceRoot: 'v1'}),
       ],
     })

--- a/angular/src/app/cockpit-area/order-cockpit/order-cockpit.component.spec.ts
+++ b/angular/src/app/cockpit-area/order-cockpit/order-cockpit.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -15,15 +16,16 @@ describe('OrderCockpitComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ OrderCockpitComponent ],
-      providers: [ WaiterCockpitService, PriceCalculatorService ],
+      declarations: [OrderCockpitComponent],
+      providers: [WaiterCockpitService, PriceCalculatorService, HttpClient],
       imports: [
         CoreModule,
-        BackendModule.forRoot({environmentType: 0, restServiceRoot: 'v1'}),
+        BackendModule.forRoot({ environmentType: 0, restServiceRoot: 'v1' }),
         BrowserAnimationsModule,
+        HttpClientModule,
       ],
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/angular/src/app/cockpit-area/order-cockpit/order-dialog/order-dialog.component.spec.ts
+++ b/angular/src/app/cockpit-area/order-cockpit/order-dialog/order-dialog.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDialog } from '@angular/material';
@@ -17,20 +18,21 @@ describe('OrderDialogComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      providers: [ WaiterCockpitService, PriceCalculatorService ],
+      providers: [WaiterCockpitService, PriceCalculatorService, HttpClient],
       imports: [
         BrowserAnimationsModule,
         WaiterCockpitModule,
         CoreModule,
-        BackendModule.forRoot({environmentType: 0, restServiceRoot: 'v1'}),
+        HttpClientModule,
+        BackendModule.forRoot({ environmentType: 0, restServiceRoot: 'v1' }),
       ],
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
     dialog = TestBed.get(MatDialog);
-    component = dialog.open(OrderDialogComponent, { data : {dialogData: { row: undefined }}}).componentInstance;
+    component = dialog.open(OrderDialogComponent, { data: { dialogData: { row: undefined } } }).componentInstance;
   });
 
   it('should create', () => {

--- a/angular/src/app/cockpit-area/reservation-cockpit/reservation-cockpit.component.spec.ts
+++ b/angular/src/app/cockpit-area/reservation-cockpit/reservation-cockpit.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { DatePipe } from '@angular/common';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -16,15 +17,16 @@ describe('ReservationCockpitComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ReservationCockpitComponent ],
-      providers: [  WaiterCockpitService, PriceCalculatorService ],
+      declarations: [ReservationCockpitComponent],
+      providers: [WaiterCockpitService, PriceCalculatorService, HttpClient],
       imports: [
         CoreModule,
-        BackendModule.forRoot({environmentType: 0, restServiceRoot: 'v1'}),
+        BackendModule.forRoot({ environmentType: 0, restServiceRoot: 'v1' }),
         BrowserAnimationsModule,
+        HttpClientModule,
       ],
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/angular/src/app/cockpit-area/reservation-cockpit/reservation-dialog/reservation-dialog.component.spec.ts
+++ b/angular/src/app/cockpit-area/reservation-cockpit/reservation-dialog/reservation-dialog.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDialog } from '@angular/material';
@@ -17,20 +18,21 @@ describe('ReservationDialogComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      providers: [ WaiterCockpitService, PriceCalculatorService ],
+      providers: [WaiterCockpitService, PriceCalculatorService, HttpClient],
       imports: [
         BrowserAnimationsModule,
         WaiterCockpitModule,
         CoreModule,
-        BackendModule.forRoot({environmentType: 0, restServiceRoot: 'v1'}),
+        HttpClientModule,
+        BackendModule.forRoot({ environmentType: 0, restServiceRoot: 'v1' }),
       ],
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
     dialog = TestBed.get(MatDialog);
-    component = dialog.open(ReservationDialogComponent, { data : {dialogData: { row: undefined }}}).componentInstance;
+    component = dialog.open(ReservationDialogComponent, { data: { dialogData: { row: undefined } } }).componentInstance;
   });
 
   it('should create', () => {

--- a/angular/src/app/cockpit-area/shared/waiter-cockpit.service.ts
+++ b/angular/src/app/cockpit-area/shared/waiter-cockpit.service.ts
@@ -3,13 +3,13 @@ import { Observable } from 'rxjs/Observable';
 import { PriceCalculatorService } from '../../sidenav/shared/price-calculator.service';
 import { OrderDataService } from '../../backend/order/order-data-service';
 import { BookingDataService } from '../../backend/booking/booking-data-service';
-import { FilterCockpit, Pagination, Sorting,  } from '../../backend/backendModels/interfaces';
+import { FilterCockpit, Pagination, Sorting, } from '../../backend/backendModels/interfaces';
 import {
-    BookingResponse,
-    OrderListView,
-    OrderResponse,
-    OrderView,
-    ReservationView,
+  BookingResponse,
+  OrderListView,
+  OrderResponse,
+  OrderView,
+  ReservationView,
 } from '../../shared/viewModels/interfaces';
 import { map, cloneDeep } from 'lodash';
 
@@ -17,8 +17,8 @@ import { map, cloneDeep } from 'lodash';
 export class WaiterCockpitService {
 
   constructor(private orderDataService: OrderDataService,
-              private bookingDataService: BookingDataService,
-              private priceCalculator: PriceCalculatorService) { }
+    private bookingDataService: BookingDataService,
+    private priceCalculator: PriceCalculatorService) { }
 
   getOrders(pagination: Pagination, sorting: Sorting[], filters: FilterCockpit): Observable<OrderResponse[]> {
     filters.pagination = pagination;
@@ -32,16 +32,16 @@ export class WaiterCockpitService {
     return this.bookingDataService.getReservations(filters);
   }
   orderComposer(orderList: OrderView[]): OrderView[] {
-      let orders: OrderView[] = cloneDeep(orderList);
-      map(orders, (o: OrderView) => {
-        o.dish.price = this.priceCalculator.getPrice(o);
-        o.extras = map(o.extras, 'name').join(', ');
-      });
-      return orders;
+    let orders: OrderView[] = cloneDeep(orderList);
+    map(orders, (o: OrderView) => {
+      o.dish.price = this.priceCalculator.getPrice(o);
+      o.extras = map(o.extras, 'name').join(', ');
+    });
+    return orders;
   }
 
   getTotalPrice(orderLines: OrderView[]): number {
-     return this.priceCalculator.getTotalPrice(orderLines);
+    return this.priceCalculator.getTotalPrice(orderLines);
   }
 
 }

--- a/angular/src/app/cockpit-area/shared/waiter-cockpit.service.ts
+++ b/angular/src/app/cockpit-area/shared/waiter-cockpit.service.ts
@@ -3,13 +3,13 @@ import { Observable } from 'rxjs/Observable';
 import { PriceCalculatorService } from '../../sidenav/shared/price-calculator.service';
 import { OrderDataService } from '../../backend/order/order-data-service';
 import { BookingDataService } from '../../backend/booking/booking-data-service';
-import { FilterCockpit, Pagination, Sorting, } from '../../backend/backendModels/interfaces';
+import { FilterCockpit, Pagination, Sorting,  } from '../../backend/backendModels/interfaces';
 import {
-  BookingResponse,
-  OrderListView,
-  OrderResponse,
-  OrderView,
-  ReservationView,
+    BookingResponse,
+    OrderListView,
+    OrderResponse,
+    OrderView,
+    ReservationView,
 } from '../../shared/viewModels/interfaces';
 import { map, cloneDeep } from 'lodash';
 
@@ -17,8 +17,8 @@ import { map, cloneDeep } from 'lodash';
 export class WaiterCockpitService {
 
   constructor(private orderDataService: OrderDataService,
-    private bookingDataService: BookingDataService,
-    private priceCalculator: PriceCalculatorService) { }
+              private bookingDataService: BookingDataService,
+              private priceCalculator: PriceCalculatorService) { }
 
   getOrders(pagination: Pagination, sorting: Sorting[], filters: FilterCockpit): Observable<OrderResponse[]> {
     filters.pagination = pagination;
@@ -32,16 +32,16 @@ export class WaiterCockpitService {
     return this.bookingDataService.getReservations(filters);
   }
   orderComposer(orderList: OrderView[]): OrderView[] {
-    let orders: OrderView[] = cloneDeep(orderList);
-    map(orders, (o: OrderView) => {
-      o.dish.price = this.priceCalculator.getPrice(o);
-      o.extras = map(o.extras, 'name').join(', ');
-    });
-    return orders;
+      let orders: OrderView[] = cloneDeep(orderList);
+      map(orders, (o: OrderView) => {
+        o.dish.price = this.priceCalculator.getPrice(o);
+        o.extras = map(o.extras, 'name').join(', ');
+      });
+      return orders;
   }
 
   getTotalPrice(orderLines: OrderView[]): number {
-    return this.priceCalculator.getTotalPrice(orderLines);
+     return this.priceCalculator.getTotalPrice(orderLines);
   }
 
 }

--- a/angular/src/app/cockpit-area/shared/waiter-cockpit.service.ts
+++ b/angular/src/app/cockpit-area/shared/waiter-cockpit.service.ts
@@ -3,39 +3,45 @@ import { Observable } from 'rxjs/Observable';
 import { PriceCalculatorService } from '../../sidenav/shared/price-calculator.service';
 import { OrderDataService } from '../../backend/order/order-data-service';
 import { BookingDataService } from '../../backend/booking/booking-data-service';
-import { FilterCockpit, Pagination, Sorting } from '../../backend/backendModels/interfaces';
-import { OrderListView, OrderView, ReservationView } from '../../shared/viewModels/interfaces';
+import { FilterCockpit, Pagination, Sorting, } from '../../backend/backendModels/interfaces';
+import {
+  BookingResponse,
+  OrderListView,
+  OrderResponse,
+  OrderView,
+  ReservationView,
+} from '../../shared/viewModels/interfaces';
 import { map, cloneDeep } from 'lodash';
 
 @Injectable()
 export class WaiterCockpitService {
 
   constructor(private orderDataService: OrderDataService,
-              private bookingDataService: BookingDataService,
-              private priceCalculator: PriceCalculatorService) { }
+    private bookingDataService: BookingDataService,
+    private priceCalculator: PriceCalculatorService) { }
 
-  getOrders(pagination: Pagination, sorting: Sorting[], filters: FilterCockpit): Observable<OrderListView[]> {
+  getOrders(pagination: Pagination, sorting: Sorting[], filters: FilterCockpit): Observable<OrderResponse[]> {
     filters.pagination = pagination;
     filters.sort = sorting;
     return this.orderDataService.getBookingOrders(filters);
   }
 
-  getReservations(pagination: Pagination, sorting: Sorting[], filters: FilterCockpit): Observable<ReservationView[]> {
+  getReservations(pagination: Pagination, sorting: Sorting[], filters: FilterCockpit): Observable<BookingResponse[]> {
     filters.pagination = pagination;
     filters.sort = sorting;
     return this.bookingDataService.getReservations(filters);
   }
   orderComposer(orderList: OrderView[]): OrderView[] {
-      let orders: OrderView[] = cloneDeep(orderList);
-      map(orders, (o: OrderView) => {
-        o.dish.price = this.priceCalculator.getPrice(o);
-        o.extras = map(o.extras, 'name').join(', ');
-      });
-      return orders;
+    let orders: OrderView[] = cloneDeep(orderList);
+    map(orders, (o: OrderView) => {
+      o.dish.price = this.priceCalculator.getPrice(o);
+      o.extras = map(o.extras, 'name').join(', ');
+    });
+    return orders;
   }
 
   getTotalPrice(orderLines: OrderView[]): number {
-     return this.priceCalculator.getTotalPrice(orderLines);
+    return this.priceCalculator.getTotalPrice(orderLines);
   }
 
 }

--- a/angular/src/app/core/core.module.ts
+++ b/angular/src/app/core/core.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import {
   MatAutocompleteModule,

--- a/angular/src/app/core/httpClient/Interceptor.module.ts
+++ b/angular/src/app/core/httpClient/Interceptor.module.ts
@@ -1,0 +1,28 @@
+import { Injectable, NgModule } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest } from '@angular/common/http';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { AuthService } from '../authentication/auth.service';
+@Injectable()
+export class HttpsRequestInterceptor implements HttpInterceptor {
+    constructor(private auth: AuthService) {}
+    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+        // Get the auth header from the service.
+        const authHeader: string = this.auth.getToken();
+        if(authHeader){
+            const authReq = req.clone({setHeaders: {Authorization: authHeader}});
+            /* const customReq = req.clone({
+                headers: req.headers.set('app-language', 'it')
+              }); */
+            return next.handle(authReq);
+        }else{
+            return next.handle(req);
+        }
+    }
+};
+@NgModule({
+    providers: [
+        { provide: HTTP_INTERCEPTORS, useClass: HttpsRequestInterceptor, multi: true }
+    ]
+})
+export class InterceptorModule { }

--- a/angular/src/app/email-confirmations/email-confirmations.component.spec.ts
+++ b/angular/src/app/email-confirmations/email-confirmations.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs/Rx';
@@ -16,24 +17,27 @@ describe('EmailConfirmationsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ EmailConfirmationsComponent ],
+      declarations: [EmailConfirmationsComponent],
       providers: [
-          SnackBarService,
-          EmailConfirmationsService,
-          { provide: ActivatedRoute,
-                     useValue: {
-                         url: Observable.of([{path: 'booking'}, {path: 'cancel'}]),
-                         params: Observable.of({id: 123}),
-                     },
-          }],
+        SnackBarService,
+        EmailConfirmationsService,
+        HttpClient,
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            url: Observable.of([{ path: 'booking' }, { path: 'cancel' }]),
+            params: Observable.of({ id: 123 }),
+          },
+        }],
       imports: [
         CoreModule,
-        BackendModule.forRoot({environmentType: 0, restServiceRoot: 'v1'}),
+        BackendModule.forRoot({ environmentType: 0, restServiceRoot: 'v1' }),
         BrowserAnimationsModule,
         RouterTestingModule,
+        HttpClientModule,
       ],
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/angular/src/app/email-confirmations/email-confirmations.component.ts
+++ b/angular/src/app/email-confirmations/email-confirmations.component.ts
@@ -1,3 +1,4 @@
+import { InvitationResponse } from '../shared/viewModels/interfaces';
 import { EmailConfirmationsService } from './shared/email-confirmations.service';
 import { Observable } from 'rxjs/Rx';
 import { SnackBarService } from '../core/snackService/snackService.service';
@@ -13,54 +14,54 @@ import { Component, OnInit } from '@angular/core';
 export class EmailConfirmationsComponent implements OnInit {
 
   constructor(private snackBarService: SnackBarService,
-              private emailService: EmailConfirmationsService,
-              private router: Router,
-              private route: ActivatedRoute) { }
+    private emailService: EmailConfirmationsService,
+    private router: Router,
+    private route: ActivatedRoute) { }
 
   ngOnInit(): void {
     this.route.params.switchMap((params: Params) => Observable.of(params.token))
-        .subscribe((token: string) => {
-           this.route.url
-               .subscribe((data: UrlSegment[]) => {
-                  switch (data[1].path) {
-                    case 'acceptInvite':
-                        this.emailService.sendAcceptInvitation(token).subscribe((res: number) => {
-                          this.snackBarService.openSnack('Invitation succesfully accepted', 10000, 'green');
-                        },
-                        (error: any) => {
-                          this.snackBarService.openSnack('An error has ocurred, please try again later', 10000, 'red');
-                        });
-                        break;
-                    case 'rejectInvite':
-                        this.emailService.sendRejectInvitation(token).subscribe((res: number) => {
-                          this.snackBarService.openSnack('Invitation succesfully rejected', 10000, 'red');
-                        },
-                        (error: any) => {
-                          this.snackBarService.openSnack('An error has ocurred, please try again later', 10000, 'red');
-                        });
-                        break;
-                    case 'cancel':
-                        this.emailService.sendCancelBooking(token).subscribe((res: number) => {
-                          this.snackBarService.openSnack('Booking succesfully canceled', 10000, 'green');
-                        },
-                        (error: any) => {
-                          this.snackBarService.openSnack('An error has ocurred, please try again later', 10000, 'red');
-                        });
-                        break;
-                    case 'cancelOrder':
-                        this.emailService.sendCancelOrder(token).subscribe((res: number) => {
-                          this.snackBarService.openSnack('Order succesfully canceled', 10000, 'green');
-                        },
-                        (error: any) => {
-                          this.snackBarService.openSnack('An error has ocurred, please try again later', 10000, 'red');
-                        });
-                        break;
-                    default:
-                        this.snackBarService.openSnack('Url not found, please try again', 10000, 'black');
-                        break;
-                  }
-               });
-        });
+      .subscribe((token: string) => {
+        this.route.url
+          .subscribe((data: UrlSegment[]) => {
+            switch (data[1].path) {
+              case 'acceptInvite':
+                this.emailService.sendAcceptInvitation(token).subscribe((res: InvitationResponse) => {
+                  this.snackBarService.openSnack('Invitation succesfully accepted', 10000, 'green');
+                },
+                  (error: any) => {
+                    this.snackBarService.openSnack('An error has ocurred, please try again later', 10000, 'red');
+                  });
+                break;
+              case 'rejectInvite':
+                this.emailService.sendRejectInvitation(token).subscribe((res: InvitationResponse) => {
+                  this.snackBarService.openSnack('Invitation succesfully rejected', 10000, 'red');
+                },
+                  (error: any) => {
+                    this.snackBarService.openSnack('An error has ocurred, please try again later', 10000, 'red');
+                  });
+                break;
+              case 'cancel':
+                this.emailService.sendCancelBooking(token).subscribe((res: InvitationResponse) => {
+                  this.snackBarService.openSnack('Booking succesfully canceled', 10000, 'green');
+                },
+                  (error: any) => {
+                    this.snackBarService.openSnack('An error has ocurred, please try again later', 10000, 'red');
+                  });
+                break;
+              case 'cancelOrder':
+                this.emailService.sendCancelOrder(token).subscribe((res: boolean) => {
+                  this.snackBarService.openSnack('Order succesfully canceled', 10000, 'green');
+                },
+                  (error: any) => {
+                    this.snackBarService.openSnack('An error has ocurred, please try again later', 10000, 'red');
+                  });
+                break;
+              default:
+                this.snackBarService.openSnack('Url not found, please try again', 10000, 'black');
+                break;
+            }
+          });
+      });
     this.router.navigate(['restaurant']);
   }
 

--- a/angular/src/app/email-confirmations/shared/email-confirmations.service.spec.ts
+++ b/angular/src/app/email-confirmations/shared/email-confirmations.service.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { TestBed, inject } from '@angular/core/testing';
 import { HttpModule } from '@angular/http';
 import { BookingInMemoryService } from '../../backend/booking/booking-in-memory.service';
@@ -9,11 +10,12 @@ import { BookingDataService } from '../../backend/booking/booking-data-service';
 describe('EmailConfirmationsService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpModule],
+      imports: [HttpModule, HttpClientModule],
       providers: [
         EmailConfirmationsService,
-        {provide: BookingDataService, useClass: BookingInMemoryService},
-        {provide: OrderDataService, useClass: OrderInMemoryService}],
+        HttpClient,
+        { provide: BookingDataService, useClass: BookingInMemoryService },
+        { provide: OrderDataService, useClass: OrderInMemoryService }],
     });
   });
 

--- a/angular/src/app/email-confirmations/shared/email-confirmations.service.ts
+++ b/angular/src/app/email-confirmations/shared/email-confirmations.service.ts
@@ -1,3 +1,4 @@
+import { InvitationResponse } from '../../shared/viewModels/interfaces';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { OrderDataService } from '../../backend/order/order-data-service';
@@ -7,21 +8,21 @@ import { BookingDataService } from '../../backend/booking/booking-data-service';
 export class EmailConfirmationsService {
 
   constructor(private orderDataService: OrderDataService,
-              private bookingDataService: BookingDataService) { }
+    private bookingDataService: BookingDataService) { }
 
-  sendAcceptInvitation(token: string): Observable<number> {
+  sendAcceptInvitation(token: string): Observable<InvitationResponse> {
     return this.bookingDataService.acceptInvite(token);
   }
 
-  sendRejectInvitation(token: string): Observable<number> {
+  sendRejectInvitation(token: string): Observable<InvitationResponse> {
     return this.bookingDataService.cancelInvite(token);
   }
 
-  sendCancelBooking(token: string): Observable<number> {
+  sendCancelBooking(token: string): Observable<InvitationResponse> {
     return this.bookingDataService.cancelReserve(token);
   }
 
-  sendCancelOrder(token: string): Observable<number> {
+  sendCancelOrder(token: string): Observable<boolean> {
     return this.orderDataService.cancelOrder(token);
   }
 }

--- a/angular/src/app/header/header.component.spec.ts
+++ b/angular/src/app/header/header.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RouterTestingModule } from '@angular/router/testing';
@@ -19,16 +20,17 @@ describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
 
-  beforeEach(async() => {
+  beforeEach(async () => {
     TestBed.configureTestingModule({
       declarations: [HeaderComponent],
-      providers: [WindowService, AuthService, UserAreaService, SnackBarService],
+      providers: [WindowService, AuthService, UserAreaService, SnackBarService, HttpClient],
       imports: [
         RouterTestingModule,
         BrowserAnimationsModule,
-        BackendModule.forRoot({environmentType: 0, restServiceRoot: 'v1'}),
+        BackendModule.forRoot({ environmentType: 0, restServiceRoot: 'v1' }),
         CoreModule,
         SidenavModule,
+        HttpClientModule,
       ],
     });
     TestBed.compileComponents();

--- a/angular/src/app/menu/menu.component.spec.ts
+++ b/angular/src/app/menu/menu.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
@@ -16,15 +17,16 @@ describe('MenuComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ MenuComponent, MenuCardComponent ],
-      providers: [SidenavService, MenuService, SnackBarService, AuthService],
+      declarations: [MenuComponent, MenuCardComponent],
+      providers: [SidenavService, MenuService, SnackBarService, AuthService, HttpClient],
       imports: [
         BrowserAnimationsModule,
-        BackendModule.forRoot({environmentType: 0, restServiceRoot: 'v1'}),
+        BackendModule.forRoot({ environmentType: 0, restServiceRoot: 'v1' }),
         CoreModule,
+        HttpClientModule,
       ],
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/angular/src/app/shared/viewModels/interfaces.ts
+++ b/angular/src/app/shared/viewModels/interfaces.ts
@@ -1,11 +1,12 @@
 // DISHES
+import { Pagination } from '../../backend/backendModels/interfaces';
 export interface DishView {
     dish: PlateView;
-    image: {content: string};
+    image: { content: string };
     extras: ExtraView[];
     likes: number;
     isfav: boolean;
-    categories?: {id: string}[];
+    categories?: { id: string }[];
 }
 
 export interface PlateView {
@@ -20,6 +21,11 @@ export interface ExtraView {
     name: string;
     price: number;
     selected?: boolean;
+}
+
+export interface DishResponse {
+    pagination: Pagination;
+    result: DishView;
 }
 
 // BOOKING
@@ -59,4 +65,50 @@ export interface OrderView {
 export interface OrderListView {
     orderLines: OrderView[];
     booking: BookingView;
+}
+
+// Interface to recieve responeses from the server using httpclient for getReservations
+export interface BookingResponse {
+    pagination: Pagination;
+    result: ReservationView;
+}
+
+// Interface to recieve responeses from the server using httpclient for get orders
+export interface OrderResponse {
+    pagination: Pagination;
+    result: OrderListView;
+}
+
+// Interface to recieve responeses from the server using httpclient for email invitations
+export interface InvitationResponse {
+    id: number;
+    modificationCounter: number;
+    accepted: boolean;
+    guestToken: string;
+    modificationDate: any;
+    revision: any;
+}
+
+// Not sure if this should just use bookingview interface, just in case Im creating a new interface that extends booking view
+export interface BookingTableResponse extends BookingView {
+    bookingType: string;
+    canceled: false;
+    comment: string;
+    expeditionDate: string;
+    id: number;
+    modificationCounter: number;
+    orderId: number;
+    revision: any;
+    userId: number;
+}
+
+// Interface to recieve responeses from the server using httpclient for SaveOrders
+export interface SaveOrderResponse {
+    bookingId: number;
+    bokingToken: string;
+    hostId: number;
+    id: number;
+    invitedGuestId: number;
+    modificationCounter: number;
+    revision: any;
 }

--- a/angular/src/app/sidenav/shared/sidenav.service.ts
+++ b/angular/src/app/sidenav/shared/sidenav.service.ts
@@ -2,7 +2,7 @@ import { Observable } from 'rxjs/Observable';
 import { Injectable } from '@angular/core';
 import { OrderDataService } from '../../backend/order/order-data-service';
 import { SnackBarService } from '../../core/snackService/snackService.service';
-import { OrderView, ExtraView } from '../../shared/viewModels/interfaces';
+import { ExtraView, OrderView, SaveOrderResponse } from '../../shared/viewModels/interfaces';
 import { OrderListInfo, OrderInfo } from '../../backend/backendModels/interfaces';
 import { find, filter, isEqual, remove, cloneDeep, toString } from 'lodash';
 
@@ -65,7 +65,7 @@ export class SidenavService {
     return this.orders;
   }
 
-  public sendOrders(token: string): Observable<number> {
+  public sendOrders(token: string): Observable<SaveOrderResponse> {
 
     let orderList: OrderListInfo = {
       booking: {bookingToken: token},

--- a/angular/src/app/user-area/password-dialog/password-dialog.component.spec.ts
+++ b/angular/src/app/user-area/password-dialog/password-dialog.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDialog } from '@angular/material';
@@ -18,16 +19,17 @@ describe('PasswordDialogComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      providers: [ SnackBarService, AuthService ],
+      providers: [SnackBarService, AuthService, HttpClient],
       imports: [
         CoreModule,
         RouterTestingModule,
         BrowserAnimationsModule,
         UserAreaModule,
-        BackendModule.forRoot({environmentType: 0, restServiceRoot: 'v1'}),
+        HttpClientModule,
+        BackendModule.forRoot({ environmentType: 0, restServiceRoot: 'v1' }),
       ],
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/angular/src/app/user-area/shared/user-area.service.ts
+++ b/angular/src/app/user-area/shared/user-area.service.ts
@@ -1,6 +1,6 @@
 import { Router } from '@angular/router';
 import { LoginInfo } from '../../backend/backendModels/interfaces';
-import { Injectable }     from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Rx';
 import { LoginDataService } from '../../backend/login/login-data-service';
 import { SnackBarService } from '../../core/snackService/snackService.service';
@@ -10,26 +10,26 @@ import { AuthService } from '../../core/authentication/auth.service';
 export class UserAreaService {
 
     constructor(public snackBar: SnackBarService,
-                public router: Router,
-                public authService: AuthService,
-                public loginDataService: LoginDataService) { }
+        public router: Router,
+        public authService: AuthService,
+        public loginDataService: LoginDataService) { }
 
     login(username: string, password: string): void {
         this.loginDataService.login(username, password)
             .subscribe((res: any) => {
                 this.authService.setToken(res.headers.get('Authorization'));
                 this.loginDataService.getCurrentUser()
-                    .subscribe( (loginInfo: any) => {
+                    .subscribe((loginInfo: any) => {
                         this.authService.setLogged(true);
                         this.authService.setUser(loginInfo.name);
                         this.authService.setRole(loginInfo.role);
                         this.router.navigate(['orders']);
                         this.snackBar.openSnack('Login successful', 4000, 'green');
                     });
-                }, (err: any) => {
-                    this.authService.setLogged(false);
-                    this.snackBar.openSnack(err.json().message, 4000, 'red');
-                });
+            }, (err: any) => {
+                this.authService.setLogged(false);
+                this.snackBar.openSnack(err.message, 4000, 'red');
+            });
     }
 
     register(email: string, password: string): void {
@@ -53,11 +53,11 @@ export class UserAreaService {
     changePassword(data: any): void {
         data.username = this.authService.getUser();
         this.loginDataService.changePassword(data.username, data.oldPassword, data.newPassword)
-            .subscribe( (res: any) => {
-                    this.snackBar.openSnack(res.message, 4000, 'green');
-                }, (error: any) => {
-                    this.snackBar.openSnack(error.message, 4000, 'red');
-                });
+            .subscribe((res: any) => {
+                this.snackBar.openSnack(res.message, 4000, 'green');
+            }, (error: any) => {
+                this.snackBar.openSnack(error.message, 4000, 'red');
+            });
     }
 
 }


### PR DESCRIPTION
Included on this pull request is also a small patch that needs a bigger fix on the routing module. In this commit, all rest calls now use the httpclient implementation from angular 4.3. Also, the interceptor module has been created and inserts the token in server calls from the client if a token is available.

TODO:
- Check router fix (current fix should only be a temporary patch)
- Currently, httpclientmodule is loaded in the app module. Perhaps the correct approach would be that each rest module should have their own httpclientmodule import, in order for them to be more modular.