### PR TITLE
Modify JWT "scope" claim to hold a List<String>

### DIFF
--- a/java/mtsj/core/src/main/java/io/oasp/application/mtsj/general/security/TokenAuthenticationService.java
+++ b/java/mtsj/core/src/main/java/io/oasp/application/mtsj/general/security/TokenAuthenticationService.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -53,6 +52,8 @@ public class TokenAuthenticationService {
   static final String CLAIM_CREATED = "iat";
 
   static final String CLAIM_SCOPE = "scope";
+
+  static final String CLAIM_ROLES = "roles";
 
   /**
    * This method returns the token once the Authentication has been successful
@@ -110,7 +111,8 @@ public class TokenAuthenticationService {
     Map<String, Object> claims = new HashMap<>();
     claims.put(CLAIM_ISSUER, ISSUER);
     claims.put(CLAIM_SUBJECT, auth.getName());
-    claims.put(CLAIM_SCOPE, auth.getAuthorities());
+    claims.put(CLAIM_SCOPE, scopes);
+    claims.put(CLAIM_ROLES, scopes);
     claims.put(CLAIM_CREATED, generateCreationDate() / 1000);
     claims.put(CLAIM_EXPIRATION, generateExpirationDate() / 1000);
     LOG.info(claims.toString());
@@ -162,15 +164,8 @@ public class TokenAuthenticationService {
 
   static List<String> getRolesFromToken(String token) {
 
-    List<LinkedHashMap> scopes = Jwts.parser().setSigningKey(SECRET).parseClaimsJws(token.replace(TOKEN_PREFIX, ""))
-        .getBody().get(CLAIM_SCOPE, List.class);
-
-    List<String> roles = new ArrayList<>();
-    for (LinkedHashMap<?, ?> scope : scopes) {
-      roles.add(scope.get("authority").toString());
-    }
-
-    return roles;
+    return Jwts.parser().setSigningKey(SECRET).parseClaimsJws(token.replace(TOKEN_PREFIX, "")).getBody()
+        .get(CLAIM_SCOPE, List.class);
   }
 
 }


### PR DESCRIPTION
Modified JWT payload to hold scope and roles claims as a List<String> instead of the more complex List<GrantedAuthority>.

Moreover, now is consistent with the "scope" claim specified in the docs:
https://github.com/oasp/my-thai-star/wiki/java-design#token-set-up.