### PR TITLE
remove reverse-proxy reference on angular nginx

### DIFF
--- a/angular/nginx.conf
+++ b/angular/nginx.conf
@@ -4,10 +4,6 @@ server {
 
     try_files $uri $uri/ /index.html;
 
-    location /api {
-        proxy_pass http://reverse-proxy:80/api;
-    }
-
     error_log /var/log/nginx/devonfw_angular_error.log;
     access_log /var/log/nginx/devonfw_angular_access.log;
 }


### PR DESCRIPTION
There should be no need for the reference to reverse-proxy on the angular http server.

This seems coming from previous versions where the angular http server also acted as reverse proxy for the backend. It is not still the case, right?

This causes problems when deploying if the reverse-proxy is not already running when this is started
(nginx: [emerg] host not found in upstream "reverse-proxy" in /etc/nginx/conf.d/default.conf:8 )

