### PR TITLE
Docker build and run fixed

### DIFF
--- a/angular/Dockerfile
+++ b/angular/Dockerfile
@@ -5,7 +5,7 @@ COPY . /app
 RUN npm i -g @angular/cli
 RUN apk update && apk add yarn
 RUN yarn
-RUN ng build --environment=docker --prod --build-optimizer
+RUN ng build --configuration=docker --prod --build-optimizer
 
 # 2. Deploy
 FROM nginx:latest

--- a/angular/Dockerfile.travis
+++ b/angular/Dockerfile.travis
@@ -6,4 +6,4 @@ COPY . /app
 RUN npm i -g @angular/cli
 RUN apk update && apk add yarn
 RUN yarn
-RUN ng build --environment=docker --prod --build-optimizer
+RUN ng build --configuration=docker --prod --build-optimizer


### PR DESCRIPTION
Docker build and run was not working due to an error in the `ng build` command related to the Angular 6 update. 