### PR TITLE
Modify Java Dockerfile to use java8 instead of tomcat

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -5,8 +5,15 @@ COPY mtsj/. /app
 RUN ls -l
 RUN mvn install
 
-# 2. Deploy
-FROM tomcat:latest
+# 2. Deploy Tomcat version
+# FROM tomcat:latest
+# WORKDIR /app
+# COPY --from=build /app/server/target/mythaistar.war /usr/local/tomcat/webapps/
+# EXPOSE 8080
+
+# 3. Deploy jar
+FROM java:8
 WORKDIR /app
-COPY --from=build /app/server/target/mythaistar.war /usr/local/tomcat/webapps/
+ADD /server/target/mtsj-server-bootified.war mtsj-server-bootified.war
+ENTRYPOINT ["java","-jar","mtsj-server-bootified.war"]
 EXPOSE 8080

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -5,18 +5,9 @@ COPY mtsj/. /app
 RUN ls -l
 RUN mvn install
 
-# 2. Deploy Tomcat version
-# FROM tomcat:latest
-# WORKDIR /app
-# COPY --from=build /app/server/target/mythaistar.war /usr/local/tomcat/webapps/
-# EXPOSE 8080
-
-# 3. Deploy jar
+# 2. Deploy Java war
 FROM java:8
 WORKDIR /app
 COPY --from=build /app/server/target/mtsj-server-bootified.war /app/
-# ADD /app/server/target/mtsj-server-bootified.war mtsj-server.war
-# ADD /root/.m2/repository/io/oasp/application/mtsj-server/0.1-SNAPSHOT/mtsj-server-0.1-SNAPSHOT-bootified.war mtsj-server.war
 ENTRYPOINT ["java","-jar","/app/mtsj-server-bootified.war"]
-# EXPOSE 8080
 EXPOSE 8081

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -14,6 +14,8 @@ RUN mvn install
 # 3. Deploy jar
 FROM java:8
 WORKDIR /app
-ADD /server/target/mtsj-server-bootified.war mtsj-server-bootified.war
-ENTRYPOINT ["java","-jar","mtsj-server-bootified.war"]
+COPY --from=build /app/server/target/mtsj-server-bootified.war /app/
+# ADD /app/server/target/mtsj-server-bootified.war mtsj-server.war
+# ADD /root/.m2/repository/io/oasp/application/mtsj-server/0.1-SNAPSHOT/mtsj-server-0.1-SNAPSHOT-bootified.war mtsj-server.war
+ENTRYPOINT ["java","-jar","/app/mtsj-server-bootified.war"]
 EXPOSE 8080

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -18,4 +18,5 @@ COPY --from=build /app/server/target/mtsj-server-bootified.war /app/
 # ADD /app/server/target/mtsj-server-bootified.war mtsj-server.war
 # ADD /root/.m2/repository/io/oasp/application/mtsj-server/0.1-SNAPSHOT/mtsj-server-0.1-SNAPSHOT-bootified.war mtsj-server.war
 ENTRYPOINT ["java","-jar","/app/mtsj-server-bootified.war"]
-EXPOSE 8080
+# EXPOSE 8080
+EXPOSE 8081

--- a/reverse-proxy/nginx.conf
+++ b/reverse-proxy/nginx.conf
@@ -7,7 +7,7 @@ server {
     }
 
     location /api {
-        proxy_pass http://java:8080/mythaistar;
+        proxy_pass http://java:8081/mythaistar;
     }
 
     error_log /var/log/nginx/devonfw_reverseproxy_error.log;


### PR DESCRIPTION
# Summary
As @cbeldacap told me, I have tried to use java:8 to deploy my thai star instead of tomcat. After the test, we can said using this feature the app uses 1 GiB less.

# Tests
## Performance using Java war
### When the app is newly deployed
![bootfied](https://user-images.githubusercontent.com/32701664/41605989-fbadf98a-73e2-11e8-9e78-51110d6bef30.png)

### After playing a little on Play with Docker
![bootfied-02](https://user-images.githubusercontent.com/32701664/41606002-002e90dc-73e3-11e8-9c4f-e5013e09bbe3.png)

## Performance using Tomcat
### When the app is newly deployed
![tomcat](https://user-images.githubusercontent.com/32701664/41606024-09e3a946-73e3-11e8-9bff-d9e82db15b4c.png)

### After playing a little on Play with Docker
![tomcat-02](https://user-images.githubusercontent.com/32701664/41606029-0c93f1dc-73e3-11e8-8198-1ef4a9ca7c39.png)


# Conclusion
Using docker **java: 8** instead of **tomcat** the application occupies practically 1 GiB less. This is almost a half of the total size.